### PR TITLE
Downgrade cmake requirment to 3.18.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.18)
 
 project(mesytec-mvlc
     DESCRIPTION "User space driver library for the Mesytec MVLC VME controller")


### PR DESCRIPTION
I am no cmake expert, so likely just changing the number is not the way to do it...

Reason / what I like to achieve: to build on Debian Bullseye.  At least if doxygen is not installed, or 'doc' directory is removed from CMakeLists.txt.

So rather see this pull request as a placeholder issue for ability to compile also on slightly older systems.
