### PR TITLE
Debian bullseye has ZMQ version 4.3.4.  Like this it would build.

### DIFF
--- a/src/mesytec-mvlc/mvlc_listfile_zmq_ganil.test.cc
+++ b/src/mesytec-mvlc/mvlc_listfile_zmq_ganil.test.cc
@@ -17,7 +17,7 @@ TEST(mvlc_listfile_zmq_ganil, TestListfileZmqGanil)
     zmq::socket_t sub(ctx, ZMQ_SUB);
 
     int timeout=500; //milliseconds
-#if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 7, 0)
+#if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 7, 0) && 0
     sub.set(zmq::sockopt::rcvtimeo, timeout);
     EXPECT_NO_THROW(sub.set(zmq::sockopt::subscribe, ""));
 #else


### PR DESCRIPTION
For sure, this is not right way to do it though.

Please see this pull request as a placeholder issue for building on Debian Bullseye.