### PR TITLE
extractShift not available when A2_DATA_FILTER_ALWAYS_GATHER is defined.

### DIFF
--- a/src/mesytec-mvlc/util/data_filter.h
+++ b/src/mesytec-mvlc/util/data_filter.h
@@ -91,10 +91,12 @@ inline u32 get_extract_mask(const DataFilter &filter, char marker)
     return make_cache_entry(filter, marker).extractMask;
 }
 
+#ifndef A2_DATA_FILTER_ALWAYS_GATHER
 inline u8 get_extract_shift(const DataFilter &filter, char marker)
 {
     return make_cache_entry(filter, marker).extractShift;
 }
+#endif
 
 MESYTEC_MVLC_EXPORT std::string to_string(const DataFilter &filter);
 


### PR DESCRIPTION
Fixes an (external) compile issue.

```
In file included from /net/home/daq/caendaq/mesytec-mvlc//src/mesytec-mvlc/event_builder.h:8,
                 from /net/home/daq/caendaq/mesytec-mvlc//src/mesytec-mvlc/mesytec-mvlc.h:31,
                 from src/mvlc_wrap.cpp:1:
/net/home/daq/caendaq/mesytec-mvlc//src/mesytec-mvlc/util/data_filter.h: In function ‘mesytec::mvlc::u8 mesytec::mvlc::util::get_extract_shift(const mesytec::mvlc::util::DataFilter&, char)’:
/net/home/daq/caendaq/mesytec-mvlc//src/mesytec-mvlc/util/data_filter.h:96:45: error: ‘struct mesytec::mvlc::util::CacheEntry’ has no member named ‘extractShift’; did you mean ‘extractBits’?
   96 |     return make_cache_entry(filter, marker).extractShift;
      |                                             ^~~~~~~~~~~~
      |                                             extractBits
compilation terminated due to -Wfatal-errors.
```