### PR TITLE
mdpp16_readout_example1 fixes

### DIFF
--- a/extras/mini-daq/src/mdpp16-readout-example1.cc
+++ b/extras/mini-daq/src/mdpp16-readout-example1.cc
@@ -223,7 +223,7 @@ int main()
     std::this_thread::sleep_for(std::chrono::milliseconds(500)); // wait for the reset to complete
     ec = mvlc.vmeWrite(modBase + 0x6010, irqLevel, 0x09, VMEDataWidth::D16); // module signals IRQ1
     assert(!ec);
-    ec = mvlc.vmeWrite(modBase + 0x6038, 0, 0x09, VMEDataWidth::D16); // single event, no module buffering
+    ec = mvlc.vmeWrite(modBase + 0x6036, 0, 0x09, VMEDataWidth::D16); // single event, no module buffering
     assert(!ec);
     ec = mvlc.vmeWrite(modBase + 0x6070, pulserValue, 0x09, VMEDataWidth::D16); // enable the test pulser
     assert(!ec);

--- a/extras/mini-daq/src/mdpp16-readout-example1.cc
+++ b/extras/mini-daq/src/mdpp16-readout-example1.cc
@@ -251,6 +251,10 @@ int main()
     // ConnectionType independent readout helper instance.
     ReadoutHelper rdoHelper(mvlc);
 
+    // If using ETH redirect the data stream to us.
+    ec = redirect_eth_data_stream(mvlc);
+    assert(!ec);
+
     // Enter DAQ mode. This will enable trigger processing.
     ec = enable_daq_mode(mvlc);
     assert(!ec);

--- a/src/mesytec-mvlc/mvlc_readout_parser.cc
+++ b/src/mesytec-mvlc/mvlc_readout_parser.cc
@@ -163,6 +163,10 @@ namespace
                 // SignalAccu also resets the accu
                 accumulatorActive = false;
             }
+            else if (cmd.type == StackCT::VMEWrite)
+            {
+                // VMEWrite produces no output
+            }
             else
             {
                 auto logger = get_logger("readout_parser");


### PR DESCRIPTION
From e-mail discussion.

I thought it might be more explicit to just handle the VMEWrite command in the parser.