### PR TITLE
Functional and bug fixes for fribdaq-readout

### DIFF
--- a/extras/fribdaq/Readme.md
+++ b/extras/fribdaq/Readme.md
@@ -6,9 +6,16 @@ This directory supplies an optional program, fribdaq-readout that is based on mi
  -DNSCLDAQ_ROOT=nscldaqroot
 ```
 
-where ```nscldaqroot``` is the top level directory of the FRIB/NSCLDAQ installation you want this to link against.  The softare was tested with FRIB/NSCLDAQ version ```12.1-007```, however it should operate with any version at ```11.0``` or above.
+where ```nscldaqroot``` is the top level directory of the FRIB/NSCLDAQ installation you want this to link against.  The softare was tested with FRIB/NSCLDAQ version ```12.2```,  that is the minimum NSCLDAQ version it
+can be built with.
 
-when the full mvlc support software is built, the installation ```bin``` directory will include the program ```fribdaq-readout```
+#### Prerequisite packages.
+Building the fribdaq-readout program also requires the Tcl development package.
+
+*  For Debian based distributions  this is called tcl-dev
+*  I believe for RHEL and Fedora systems this is called tcl-devel.
+
+If you are using the FRIB containerized environment this will have been installed in the container image.
 
 
 ### Using fribdaq-readout
@@ -24,17 +31,25 @@ Following all options on the command line, a single positional parameter provide
 
 ####  fribdaq-readout commands
 
-Once the program has been started successfully, it will enter a command processing loop.  This loop recognizes the following, very simple commands, which can be provided in either lower case or upper case (but not [yet] mixed  case):
+The program accepts all of the commands that a FRIB/NSCLDAQ readout framwork does.  It runs a Tcl interpreter as well.  
 
-*  ```SETRUN run-number``` sets the number of the next run. An positive integer *run-number* is the sole parameter of this command.
-This command is only accepted if the run is halted.
-* ```TITLE The title text``` sets the title to be used for the next run.  The remainder of the command line will be used as the title. This command is only accepted if the run is halted.
-* ```BEGIN``` starts taking data (begins a new run).  A data format item and a BEGIN state change item are emitted to the ringbuffer prior to any other data.  This command is only accepte if the run is halted.
-* ```PAUSE``` Pauses an active run.  After  pausing, a format item and a PAUSE state change item are emitted to the ringbuffer.
-* ```RESUME``` Resumes a paused run.  Before resuming, a format item
-and a RESUME state change item are emitted to the ringbuffer.  This command is only accepted if the run is paused.
-* ```END``` Ends a run.  This command is only acceeptd if the run is active or paused.  When the run is ended, a format item and END state change item will be emitted to the ringbuffer.
+Command:
 
+* begin
+* end
+* pause
+* resume
+* runstat
+* init
+
+Special Variables:
+
+* title - has the title that will be assigned to the next run.
+* run   - Has the run number that will be assigned to the next run.
+* state - has the current runstate, one of ```idle```, ```active``` or ```paused```
+
+Note that changes to the title an run variables while the run is not ```idle``` can be made but have no
+effect on the run number and title of the run.
 
 #### Creating setups with mdaq.
 

--- a/extras/fribdaq/src/BeginCommand.cc
+++ b/extras/fribdaq/src/BeginCommand.cc
@@ -1,0 +1,150 @@
+/**
+ * @file BeginCommand.cc
+ * @brief Implements the  Tcl command that starts a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "BeginCommand.h"
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+#include <tcl.h>
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include <chrono>
+#include "parser_callbacks.h"
+#include "StateUtils.h"
+#include <stdexcept>
+#include <sstream>
+
+using mesytec::mvlc::MVLCReadout;
+
+/**
+ * constructor
+ *    @param interp - encapsulated Tcl interpreter on which the command is registered.
+ *    @param pState - Pointer to the extended DAQ state struct.
+ *    @param pReadout - Pointer to the MVLC Readout object.
+ *    @param configFilename - Path to the yaml config file.
+ * 
+ * @note we register as the ```begin``` command.
+ */
+BeginCommand::BeginCommand(
+    CTCLInterpreter& interp, 
+    FRIBDAQRunState* pState, MVLCReadout* pReadout,
+    const std::string& configFilename
+) :
+    ReadoutCommand(interp, "begin", pState, pReadout),
+    m_configFileName(configFilename)
+     {}
+/**
+ *  destructor
+ *     provide a chain point.
+ */
+BeginCommand::~BeginCommand() {}
+
+
+/**
+ *  operator()
+ *     Executes the actual command.
+ *     Pseudo code:
+ * ```
+ *   If there is more than 1 command word, report an error.
+ *   if a begin is allowed:
+ *       If a title variable exists, copy it's value to the state's title.
+ *       If a run variable exists and is an integer, copy its value to the state's run number.
+ *       Start the run in the readout object.
+ *       Set the 'state' variable to "Active"
+ *       return TCL_OK
+ *    else:
+ *       result <-- Run cannot be started at this time.
+ * 
+ * @param interp - the interpreter the command is runnign on.
+ * @param objv   - the encapsulated command words.
+ * @return int   - TCL_OK on success, TCL_ERROR on failure.
+ */
+int
+BeginCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() > 1) {
+        interp.setResult("Too many command parameters");
+        return TCL_ERROR;
+    }
+
+    if (canBegin(*m_pReadout, *m_pRunState)) {
+        try {
+            setConfiguration();                // Update the configuration.
+            // Set title and runn um if can:
+
+            auto titlesz = getVar(interp, "title");
+            if(titlesz) m_pRunState->s_runTitle = titlesz;
+            auto runsz   = getVar(interp, "run");    // Might not convert to int so:
+            try {
+                if (runsz) {
+                    CTCLObject run;
+                    run.Bind(interp);
+                    run = runsz;
+                    m_pRunState->s_runNumber = (int)run;     // Converts object -> int rep if possible.
+                }
+                
+
+            }
+            catch(...) {
+                interp.setResult("***warning*** run number does not convert to an integer");
+            }                            // non fatal exception.
+
+            // Try to start the run:
+
+            auto ec = m_pReadout->start(std::chrono::seconds(0));              // no limit to runtime.
+            if (ec) {
+                interp.setResult(ec.message());
+                return TCL_ERROR;                                      // Readout object failed to start run.
+            }
+            m_pRunState->s_runState = Active;
+            setVar(interp, "state", "active");
+            interp.setResult("");    // In case a variabl get set result.
+        } catch (std::exception& e) {
+            std::stringstream smsg;
+            smsg << "Failed to start the run : " << e.what();
+            std::string message(smsg.str());
+            interp.setResult(message);
+            return TCL_ERROR;
+        }
+    } else {
+        // Begin with invalid state.
+
+        interp.setResult("Run canot be started when in this state");
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+
+}
+
+///////////////////// private utils.
+
+/**
+ * setConfiguration
+ *     Reprocess the configuration file and set the resulting
+ * configuration in the readout:
+ * 
+ * @throw something derived from std::exception if processing the
+ * configuration failed.
+ */
+void
+BeginCommand::setConfiguration() {
+    // Don't need to worry about scope since the confg is
+    // copied inot the readout.
+
+    mesytec::mvlc::CrateConfig config = 
+         mesytec::mvlc::crate_config_from_yaml_file(m_configFileName);
+
+    // If that parse failed, we don't get here -it throws std::runtime_error
+
+    m_pReadout->setCrateConfig(config);
+}

--- a/extras/fribdaq/src/BeginCommand.h
+++ b/extras/fribdaq/src/BeginCommand.h
@@ -1,0 +1,56 @@
+/**
+ * @file BeginCommand.h
+ * @brief Defines the Tcl command that starts a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_BEGINCOMMAND_H
+#define MVLC_BEGINCOMMAND_H
+#include "ReadoutCommand.h"
+
+#include <string>
+
+/**
+ * @class BeginCommand
+ *     This class implements the Tcl command that begins a run.
+ *   The command name is ```begin``` and does not take any parameters.
+ *   See the implementation comments for operator().
+ */
+class BeginCommand : public ReadoutCommand {
+private:
+    std::string m_configFileName;
+    // exported canonicals:
+public:
+    BeginCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout, 
+        const std::string& configFilename
+    );
+    virtual ~BeginCommand();
+
+    // Forbidden canonicals:
+private:
+    BeginCommand(const BeginCommand&);
+    BeginCommand& operator=(const BeginCommand&);
+    int operator==(const BeginCommand&);
+    int operator!=(const BeginCommand&);
+
+    // Interface methods:
+public:
+    int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+private:
+    void setConfiguration();
+};
+
+
+#endif

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -8,17 +8,31 @@ set(NSCLDAQ_ROOT "_"  CACHE STRING "_")
 if (NSCLDAQ_ROOT STREQUAL "_")    # not defined.
     
 else ()
-    
+    find_package(TCL REQUIRED)
+
+    if (NOT ${TCL_FOUND})
+        message(FATAL_ERROR, "TCl headers and libraries must be installed")
+    endif()
     add_executable(fribdaq-readout 
     fribdaq_readout.cc
-    command_parse.cc
     username.cc
     parser_callbacks.cc
+    ReadoutCommand.cc
+    StateUtils.cc
+    BeginCommand.cc
+    EndCommand.cc
+    PauseCommand.cc
+    ResumeCommand.cc
+    RunStateCommand.cc
+    InitCommand.cc
+    StatisticsCommand.cc
+    RunVarCommand.cc
     )
     target_include_directories(
         fribdaq-readout PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${NSCLDAQ_ROOT}/include
+        ${TCL_INCLUDE_PATH}
     )
     target_link_libraries(fribdaq-readout
         PRIVATE mesytec-mvlc
@@ -28,10 +42,12 @@ else ()
         PRIVATE ${NSCLDAQ_ROOT}/lib/liburl.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libdaqshm.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libDataFlow.so
+        PRIVATE ${NSCLDAQ_ROOT}/lib/libtclPlus.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libException.so
+        PRIVATE ${TCL_LIBRARY}
     )  
     target_link_options(fribdaq-readout PRIVATE
-        -ldl -Wl,-rpath=${NSCLDAQ_ROOT}/lib
+        -ldl -Wl,-rpath=${NSCLDAQ_ROOT}/lib -lm
     )  
     install(TARGETS fribdaq-readout)
 

--- a/extras/fribdaq/src/EndCommand.cc
+++ b/extras/fribdaq/src/EndCommand.cc
@@ -1,0 +1,75 @@
+/**
+ * @file EndCommand.cc
+ * @brief Implements the Tcl command that ends a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+
+ #include "EndCommand.h"
+ #include <mesytec-mvlc/mesytec-mvlc.h>
+ #include "parser_callbacks.h"
+ #include "StateUtils.h"
+ #include <tcl.h>
+ #include <TCLInterpreter.h>
+ 
+ using mesytec::mvlc::MVLCReadout;
+
+ /** constructor
+  * @param interp - intepreter on which the command will be registered.
+  * @param pState - pointer to the extra state held by the FRIB part of the daq.
+  * @param pReadout - POinter to the MVLC readout object that does the real work.
+  */
+ EndCommand::EndCommand(CTCLInterpreter& interp, FRIBDAQRunState* pState, MVLCReadout* pReadout) :
+    ReadoutCommand(interp, "end", pState, pReadout) {}
+
+/** destructor */
+EndCommand::~EndCommand() {}
+
+
+/**
+ *  operator() - does the actual work:
+ * ```
+ *    Ensure there's only one command word. If not error.
+ *    Ensure the state allows the run to stop  If not error.
+ *    Submit stop run to the Readout and report any errors that throws.
+ *    
+ * ```
+ * @param interp - interpreter executing the command.
+ * @param objv   - Command words, shoulid only have the 'end' text.
+ * @return int  - TCL_OK if the command succeeded else TCL_ERROR.
+ * 
+ */
+int
+EndCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() != 1) {
+        interp.setResult("Too many command parameters");
+        return TCL_ERROR;
+    }
+
+    if (canEnd(*m_pRunState)) {
+        auto ec =  m_pReadout->stop();
+        if (ec) {                    // Readout rejected stop...
+            interp.setResult(ec.message());
+            return TCL_ERROR;
+        } else {
+            setVar(interp, "state", "idle");
+            m_pRunState->s_runState = Halted;
+        }
+    } else {
+        // invalid state to stop..
+
+        interp.setResult("Run cannot be halted when in this state");
+        return TCL_ERROR;
+    }
+    return TCL_OK;        // Success falls through to here.
+}

--- a/extras/fribdaq/src/EndCommand.h
+++ b/extras/fribdaq/src/EndCommand.h
@@ -1,0 +1,52 @@
+/**
+ * @file EndCommand.h
+ * @brief Defines the Tcl command that ends a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_ENDRUNCOMMAND_H
+#define MVLC_ENDRUNCOMMAND_H
+
+#include "ReadoutCommand.h"
+
+
+/**
+ *  @class EndCommand
+ *      This class implements the Tcl command that ends a run
+ * The command name is ```end``` and does not take any parameters.
+ * For implementation details, see the operator() implementation comments.
+ */
+class EndCommand : public ReadoutCommand {
+    // Exported canonicals:
+
+public:
+    EndCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout 
+    );
+    virtual ~EndCommand();
+
+    // Canonicals that are not allowed.
+
+private:
+    EndCommand(const EndCommand& );
+    EndCommand& operator=(const EndCommand);
+    int operator==(const EndCommand&);
+    int operator!=(const EndCommand&);
+
+    // Virtual member overrides:
+
+    virtual int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+    
+};
+#endif

--- a/extras/fribdaq/src/InitCommand.cc
+++ b/extras/fribdaq/src/InitCommand.cc
@@ -1,0 +1,99 @@
+/**
+ * @file InitCommand.cc
+ * @brief Implements the Tcl command that initializes crate hardware.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "InitCommand.h"
+#include "StateUtils.h"
+#include "parser_callbacks.h"
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include <mesytec-mvlc/mvlc_stack_executor.h>
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+
+
+using mesytec::mvlc::CommandExecOptions;
+
+/** 
+ * constructor
+ *   @param interp - interpreter on which the command will be registered.
+ *   @param pState - Pointer to the state structure (has what we need to execute commands).
+ *   @param pReadout - Points to the readout object.
+ * 
+ * @note we register the command as "init"
+ */
+
+ InitCommand::InitCommand(
+    CTCLInterpreter& interp, 
+    FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+ ) :
+    ReadoutCommand(interp, "init", pState, pReadout) {}
+
+/**
+ * destructor
+ */
+InitCommand::~InitCommand() {}
+
+/**
+ *  operator()
+ *     Executes the command:
+ * ```
+ *     Ensure there are no additional parameters.
+ *     Ensure the run is inactive (Halted or paused).
+ *     Run the init section of the Config.
+ *     Report errors.
+ * ```
+ * 
+ *   @param interp - interpreter running the command.
+ *   @param objv   - Commmand words.
+ *   @return int - TCL_OK success, TCL_ERROR on errors.
+ *   @retval TCL_OK - in this case, and non -normal results from the list execution are
+ *      in the result as a list.
+ */
+int
+InitCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() > 1) {
+        interp.setResult("init -too many command line parameters");
+        return TCL_ERROR;
+    }
+
+    if (canBegin(*m_pReadout, *m_pRunState) || canResume(*m_pRunState)) {
+        CommandExecOptions runOpts = {
+            ignoreDelays : false,
+            continueOnVMEError  : true
+        };
+        auto statuses = mesytec::mvlc::run_commands(
+            *m_pRunState->s_interface, 
+            m_pRunState->s_config->initCommands,
+            runOpts
+        );
+        CTCLObject resultList;
+        resultList.Bind(interp);
+        for (auto& status : statuses) {
+            if (status.ec) {
+                CTCLObject result;
+                result.Bind(interp);
+                result = status.ec.message();
+                resultList += result;
+            }
+        }
+        
+        interp.setResult(resultList);
+        
+    }  else {
+        interp.setResult("init - incorrect state to initialize the hardware");
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}

--- a/extras/fribdaq/src/InitCommand.h
+++ b/extras/fribdaq/src/InitCommand.h
@@ -1,0 +1,60 @@
+/**
+ * @file InitCommand.h
+ * @brief Defines the Tcl command that initializes crate hardware.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+
+#ifndef MVLC_INITCOMMAND_H
+#define MVLC_INITCOMMAND_H
+#include "ReadoutCommand.h"
+
+struct FRIBDAQRunState;
+
+namespace mesytec {
+    namespace mvlc {
+        class MVLCReadout;
+    }
+}
+/**
+ * @class InitCommand
+ * 
+ * 
+ * This command, which takes no parameters, initializes the readout hardware specified
+ * by the configuration in the extended state.
+ */
+class InitCommand : public ReadoutCommand {
+    // Exported canonicals:
+
+public:
+    InitCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~InitCommand();
+
+    // forbidden canonicals:
+
+private:
+    InitCommand(const InitCommand&);
+    InitCommand& operator=(const InitCommand&);
+    int operator==(const InitCommand&);
+    int operator!=(const InitCommand&);
+
+    // Base class overrides.
+
+public:
+    int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+};
+
+#endif

--- a/extras/fribdaq/src/PauseCommand.cc
+++ b/extras/fribdaq/src/PauseCommand.cc
@@ -1,0 +1,85 @@
+/**
+ * @file PauseCommand.cc
+ * @brief Implements the Tcl command that pauses a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "PauseCommand.h"
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+#include <tcl.h>
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include <chrono>
+#include "parser_callbacks.h"
+#include "StateUtils.h"
+
+
+using mesytec::mvlc::MVLCReadout;    // I'm too lazy to do all that typing.
+
+/**
+ *  constructor
+ *     @param interp   - Interpreter on which we wil register the 'pause' command.
+ *     @param pState   - Additional FRIB DAQ State of the system (pointer).
+ *     @param pReadout - Pointer to the readout object that does all the work.
+ */
+PauseCommand::PauseCommand(
+    CTCLInterpreter& interp, 
+    FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+) :
+    ReadoutCommand(interp, "pause", pState, pReadout) {}
+
+/**
+ *  destructor
+ */
+PauseCommand::~PauseCommand() {}
+
+
+
+/**
+ * operator()
+ *    Performs the command:
+ * ```
+ *    Ensure there are no additional command parameters.
+ *    Ensure the state allows the run to be paused.
+ *    Attempt to pause the run, reporting any variables.
+ *    Update the state variables.
+ * ```
+ * 
+ * @param interp - interpreter that is executing the command.
+ * @param objv   - The command words.
+ * @return int   - TCL_OK on success and TCL_ERROR on error.
+ * 
+ */
+int
+PauseCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() > 1) {
+        interp.setResult("Too many command line parameters");
+        return TCL_ERROR;
+    }
+    if (canPause(*m_pRunState)) {
+        auto ec = m_pReadout->pause();
+        if (ec) {
+            interp.setResult(ec.message());
+            return TCL_ERROR;                     // Readout would not pause.
+        } else {
+            setVar(interp, "state", "paused");
+            m_pRunState->s_runState = Paused;
+        }
+    } else {
+        // Wrong state I guess.
+
+        interp.setResult("Run cannot be paused when in this state");
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}

--- a/extras/fribdaq/src/PauseCommand.h
+++ b/extras/fribdaq/src/PauseCommand.h
@@ -1,0 +1,50 @@
+/**
+ * @file PauseCommand.h
+ * @brief Defines the Tcl command that pauses a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_PAUSECOMMAND_H
+#define MVLC_PAUSECOMMAND_H
+#include "ReadoutCommand.h"
+
+/**
+ * @class PauseCOmmand
+ *    Provides the command to pause the ru8n.  The command name is ```pause```
+ * and takes no additional parameters. 
+ * 
+ * See the description of the implementation of operator() in PauseCommand.cc
+ * for more information.
+ */
+class PauseCommand : public ReadoutCommand {
+    // Exported canonicals:
+public:
+    PauseCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~PauseCommand();
+
+    // Forbidden canonicals:
+
+private:
+    PauseCommand(const PauseCommand&);
+    PauseCommand& operator=(const PauseCommand&);
+    int operator==(const PauseCommand&);
+    int operator!=(const PauseCommand&);
+
+    // Base class method overrides:
+public:
+    int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+};
+#endif

--- a/extras/fribdaq/src/ReadoutCommand.cc
+++ b/extras/fribdaq/src/ReadoutCommand.cc
@@ -1,0 +1,76 @@
+/**
+ * @file ReadoutCommand.cpp
+ * @brief Implementation of  class for all Tcl command recongized by fribdaq-readout
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "ReadoutCommand.h"
+#include <TCLVariable.h>
+
+using mesytec::mvlc::MVLCReadout;
+
+/**
+ *  constructor
+ *     @param interp  - references the interpreter the command rusn on.
+ *     @param command - command that triggers execution of this class's operator().
+ *     @param pState  - pointer to the extended run state.
+ *     @param pReadout - Pointer to the readout object.
+ * 
+ * We just initialize the base class and save the data our subclasses need.
+ */
+ReadoutCommand::ReadoutCommand(
+    CTCLInterpreter& interp, const char* command, 
+    FRIBDAQRunState* pState, MVLCReadout* pReadout
+) :
+    CTCLObjectProcessor(interp, command, TCLPLUS::kfTRUE),
+    m_pRunState(pState), m_pReadout(pReadout)
+{}
+
+/**
+ * destructor
+ */
+ReadoutCommand::~ReadoutCommand() {}
+
+
+/////////////////////////////////// Private utils ////////////////////////////////////////
+
+
+/**
+ * getVar
+ *    Get the value of a global variable in the interpreter.
+ * 
+ * @param interp - references the interp holding the var.
+ * @param name   - name of the variable.
+ * @return const char* - Pointer to the string repreentation of the variable value.
+ * @retval nullptr - if there is no such variable.
+ */
+const char*
+ReadoutCommand::getVar(CTCLInterpreter& interp, const char* name) {
+    CTCLVariable var(name, TCLPLUS::kfFALSE);
+    var.Bind(interp);
+    return var.Get();
+}
+/**
+ * setVar
+ *    Set the value of a Tcl variable.
+ * 
+ * @param interp - inteprreter the variable is in.
+ * @param name - name of the variable.
+ * @param value  - New variable value.
+ */
+void
+ReadoutCommand::setVar(CTCLInterpreter& interp, const char* name, const char* value) {
+    CTCLVariable var(name, TCLPLUS::kfFALSE);
+    var.Bind(interp);
+    var.Set(nullptr, value);
+}

--- a/extras/fribdaq/src/ReadoutCommand.h
+++ b/extras/fribdaq/src/ReadoutCommand.h
@@ -1,0 +1,67 @@
+/**
+ * @file ReadoutCommand.h
+ * @brief Base class for all Tcl command recongized by fribdaq-readout
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+ #ifndef MVLC_READOUTCOMMAND_H
+ #define MVLC_READOUTCOMMAND_H
+
+#include <TCLObjectProcessor.h>
+
+// Forward data types:
+
+struct FRIBDAQRunState;
+namespace mesytec {
+    namespace mvlc {
+        class  MVLCReadout;        
+    }
+}
+
+
+/**
+ * @class ReadoutCommand
+ * 
+ * Command processing classes that are part of the fribdaq-readout program will need
+ * to be able to access the additional daq context as well as the MVLCReadout object.
+ * So this is just a CTCLOjbectProcessor that is constructed with pointers to that 
+ * data and stores them in protected member data for subclasses to get:
+ */
+class ReadoutCommand : public CTCLObjectProcessor {
+protected:
+    FRIBDAQRunState*            m_pRunState;
+    mesytec::mvlc::MVLCReadout* m_pReadout;
+    // Canonicals are our only exports:
+public:
+    ReadoutCommand(
+        CTCLInterpreter& interp, const char* command, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~ReadoutCommand();
+
+    // Disallowed canonicals:
+
+private:
+    ReadoutCommand(const ReadoutCommand&);  // don't support copy construction.
+    ReadoutCommand& operator=(const ReadoutCommand&); // assignment
+    int operator==(ReadoutCommand&);                  // equality compare.
+    int operator!=(ReadoutCommand&);                  // inequality compare.
+
+    //utiltlies
+
+protected:
+    static const char* getVar(CTCLInterpreter& interp, const char* name);
+    static void setVar(CTCLInterpreter& interp, const char* name, const char* value);
+};
+
+ #endif

--- a/extras/fribdaq/src/ResumeCommand.cc
+++ b/extras/fribdaq/src/ResumeCommand.cc
@@ -1,0 +1,82 @@
+/**
+ * @file PauseCommand.cc
+ * @brief Implements the Tcl command that pauses a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "ResumeCommand.h"
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+#include <tcl.h>
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include <chrono>
+#include "parser_callbacks.h"
+#include "StateUtils.h"
+
+using mesytec::mvlc::MVLCReadout;
+
+
+/**
+ *  constructor
+ *    @param interp  -- TCL Interpreter the command is registered on.
+ *    @param pState   - POinter to the FRIBDAQ additional state struct.
+ *    @param pReadout - POinter t othe MVLCReadout object doing the work.
+ */
+ResumeCommand::ResumeCommand(
+    CTCLInterpreter& interp, 
+    FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+) : ReadoutCommand(interp, "resume", pState, pReadout) {}
+
+/**
+ *  destructor
+ */
+ResumeCommand::~ResumeCommand() {}
+
+
+/** 
+ * operator()
+ *     Actually perform the command:
+ * 
+ * ```
+ *   Ensure there are no additional command line parameters.
+ *   Ensure the state allows us to resume.
+ *   Attempt the resume reporting any errors/failures.
+ *   On success, update the state variables (Tcl and c++).
+ * ```
+ * @param interp - Interpreter running the command.
+ * @param objv   - The command words.
+ * @return int   - TCL_OK on success and TCL_ERROR on failure.
+ */
+int
+ResumeCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() > 1) {
+        interp.setResult("too many parameters for the 'resume' command.");
+        return TCL_ERROR;
+    }
+
+    if (canResume(*m_pRunState)) {
+        auto ec = m_pReadout->resume();
+        if (ec) {
+            interp.setResult(ec.message());
+            return TCL_ERROR;
+        } else {                             // Success.
+            m_pRunState->s_runState = Active;
+            setVar(interp, "state", "active");
+            
+        }
+    } else {
+        interp.setResult("Run cannot be resumed when in this state.");
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}

--- a/extras/fribdaq/src/ResumeCommand.h
+++ b/extras/fribdaq/src/ResumeCommand.h
@@ -1,0 +1,50 @@
+/**
+ * @file PauseCommand.h
+ * @brief Defines the Tcl command that pauses a run (if possible).
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_RESUMECOMMAND_H
+#define MVLC_RESUMECOMMAND_H
+
+#include "ReadoutCommand.h"
+
+/**
+ *  @class ResumeCommand
+ *     Class to register and implement the ```resume``` command.  The command
+ * takes no additional parameters.  See the description of operator() in ResumeCommand.cc
+ * for a description of the command itself.
+ */
+class ResumeCommand : public ReadoutCommand {
+    // Exported canonicals:
+public:
+    ResumeCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~ResumeCommand();
+    
+    // forbidden canonicals:
+private:
+    ResumeCommand(const ResumeCommand&);
+    ResumeCommand& operator=(const ResumeCommand&);
+    int operator==(const ResumeCommand&);
+    int operator!=(const ResumeCommand&);
+
+    // Base class overrides:
+
+public:
+    virtual int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+};
+
+#endif

--- a/extras/fribdaq/src/RunStateCommand.cc
+++ b/extras/fribdaq/src/RunStateCommand.cc
@@ -1,0 +1,62 @@
+/**
+ * @file RunStateCommand.cc
+ * @brief implements the command that returns the current run staste.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "RunStateCommand.h"
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+#include <TCLVariable.h>
+
+
+/**
+ *  constructor
+ * 
+ * @param interp - interpreter on which the 'runstate' command will be registered.
+ */
+
+ RunStateCommand::RunStateCommand(CTCLInterpreter& interp) :
+    CTCLObjectProcessor(interp, "runstate", TCLPLUS::kfTRUE) {}
+
+/**
+ * destructor
+ */
+RunStateCommand::~RunStateCommand() {}
+
+
+/** 
+ *  operator() 
+ *    Note if the 'state' variable is not defined, then "-undefined-" is returned.
+ * 
+ * @param interp - interpreter that's running the command.
+ * @param objv   - COmmand parameters.
+ * @return int - TCL_OK
+ */
+int 
+RunStateCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() != 1) {
+        interp.setResult("Too many command parameters");
+    }
+    CTCLVariable state("state", TCLPLUS::kfFALSE);
+    state.Bind(interp);
+
+    const char* value = state.Get();
+    if (value) {
+        interp.setResult(value);
+    } else {
+        interp.setResult("-undefined-");
+    }
+
+    return TCL_OK;
+}

--- a/extras/fribdaq/src/RunStateCommand.h
+++ b/extras/fribdaq/src/RunStateCommand.h
@@ -1,0 +1,50 @@
+/**
+ * @file RunStateCommand.h
+ * @brief Defines the command that returns the current run staste.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_RUNSTATECOMMAND_H
+#define MVLC_RUNSTATECOMMAND_H
+
+#include "TCLObjectProcessor.h"
+
+/**
+ *  @class RunStateCommand
+ * 
+ *    This is provided to support the ReST command server. It provides read acces to the
+ * 'state variable'.  Command format is just:  ```runstate``` no additional parameters.
+ */
+class RunStateCommand : public CTCLObjectProcessor {
+    // Exported canonicals:
+
+public:
+    RunStateCommand(CTCLInterpreter& interp);
+    virtual ~RunStateCommand();
+
+    // Forbidden canonicals:
+
+private:
+    RunStateCommand(const RunStateCommand&);
+    RunStateCommand& operator=(const RunStateCommand&);
+    int operator==(const RunStateCommand&);
+    int operator!=(const RunStateCommand&);
+
+    // Base class method overrides:
+
+public:
+    virtual int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+
+};
+
+#endif

--- a/extras/fribdaq/src/RunVarCommand.cc
+++ b/extras/fribdaq/src/RunVarCommand.cc
@@ -1,0 +1,288 @@
+/**
+ * @file RunVarCommand.h
+ * @brief Implements the TCL class that manages ruvars.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ * @note The 'title', 'run' variables are stocked in thte map of variables at start time.
+ */
+#include "RunVarCommand.h"
+#include <TCLInterpreter.h>
+#include "parser_callbacks.h"
+#include <TCLObject.h>
+#include <TCLVariable.h>
+#include <Exception.h>
+#include <sstream>
+// Note I don't actually need tha readout object so we won't include it's header.
+
+static const int interval(2000);    // MS between timer pops.
+
+////////////////////////// Implement the dumper class //////////////////////////////////////
+
+/**
+ *  constructor:
+ *    @param owner - References the outer object (RunVarCOmmand).
+ */
+RunVarCommand::Dumper::Dumper(RunVarCommand& owner) :
+    m_owner(owner) {
+        // Set our first timer:
+
+    Set(interval);
+}
+/**
+ * destructor
+ *    I belive the base class destructor clears any pending timer.
+ * So we can just let it do its stuff:
+ */
+RunVarCommand::Dumper::~Dumper() {}
+
+/**
+ * operator()
+ *     Reset the timer and, if the state is Active, dump the variables.
+ * Stuff is done in that order so that we can be sure the next timer pop is not
+ * influenced by the time it takes to do the dump.
+ */
+void
+RunVarCommand::Dumper::operator()() {
+    Set();                                     // reset the timer.
+    if (m_owner.m_pRunState->s_runState == Active) dumpVars();
+
+}
+/**
+ * dumpVars
+ *    Do the actual dump:
+ * ```
+ *    For each variable, 
+ *        get its value
+ *        construct a setting sctript
+ *        Add that setting script to the list of strings.
+ *    invoke the parser callbakck's dump_variables.
+ * ```
+ *   @note if a variable does not exist, It's value will be ```**Not Set**```
+ */
+void
+RunVarCommand::Dumper::dumpVars() {
+    CTCLInterpreter* pInterp = m_owner.getInterpreter();    // To fetch variables and build scripts.
+    std::vector<std::string> strings;
+    for (auto name : m_owner.m_names) {
+        CTCLVariable var(name, TCLPLUS::kfFALSE);
+        var.Bind(pInterp);
+        const char* value = var.Get();
+        std::string strValue;
+        if (value) {
+            strValue = value;
+        } else {
+            strValue = "**Not Set**";
+        }
+        std::string script = buildScript(pInterp, name.c_str(), strValue.c_str());
+        strings.push_back(script);
+    }
+    dumpVariables(*m_owner.m_pRunState, strings);
+}
+/** 
+ * buildScript
+ *     Builds a script (with appropriate quoting) to restore a varable to a value:
+ * 
+ *   @param interp - pointer to an interpreter.
+ *   @param name   - Variable name.
+ *   @param value  - Variable value.
+ *   @return std::string - string that contains a set command that will restore the variable.
+ */
+std::string
+RunVarCommand::Dumper::buildScript(CTCLInterpreter* interp, const char* name, const char* value) {
+    CTCLObject script;
+    script.Bind(interp);
+    CTCLObject element;
+    element.Bind(interp);
+
+    element = "set";
+    script += element;
+
+    element = name;
+    script += element;
+
+    element = value;
+    script += element;
+
+    return std::string(script);
+}
+
+
+//////////////////////////// Implement the runvar command - maintains the set of variable names //////////////
+
+/**
+ * constructor
+ *   @param interp - interpreter registering the command.
+ *   @param pState - Extended run state context.
+ *   @param pReadout - Readout object.
+ */
+RunVarCommand::RunVarCommand(
+    CTCLInterpreter& interp, 
+    FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+) : ReadoutCommand(interp, "runvar", pState, pReadout),
+    m_dumper(*this)
+{
+    // Insert the names that are always there.
+
+    m_names.insert("title");
+    m_names.insert("run");
+}
+
+/**
+ * destructor:
+ */
+RunVarCommand::~RunVarCommand() {}
+
+/**
+ * operator()
+ *     Figure out the subcommand and execute it.
+ *     Note that to retain compatibility with existing push scripts, no subcommand means
+ *     create.
+ *
+ *  @param interp - interpreter running the command.
+ *  @param objv - the command words.
+ *  @return int - TCL_OK on success, TCL_ERROR on failure.
+ * 
+ * @note we use exceptions internally to simplify status checks.
+ */
+int
+RunVarCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    bindAll(interp, objv);
+
+    try {
+        // There must be at least 2 command words:
+
+        requireAtLeast(objv, 2);
+        std::string subcommand = objv[1];
+
+        // If there are exactly three, words, this is a create.
+
+	if (subcommand == "create") {
+            create(interp, objv);
+        } else if (subcommand == "delete")  {
+            remove(interp, objv);
+        } else if (subcommand == "list") {
+            list(interp, objv);
+	} else if (objv.size() == 2) {
+	    create(interp, objv);
+        } else {
+            interp.setResult("ruvar - invalid subcommand");
+            return TCL_ERROR;
+        }
+    }
+    catch(CException& e) {
+        interp.setResult(e.ReasonText());
+        return TCL_ERROR;
+    }
+    catch(std::string& s) {
+        interp.setResult(s);
+        return TCL_ERROR;
+    }
+    catch(...) {
+        interp.setResult("runvar - unanticipated exception type");
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}
+
+/**
+ * create
+ *     Create a new variable. 
+ * 
+ * If there's only a single param we take it as the name.
+ *  Note that if the variable does not exist it is created with an empty string value.
+ * 
+ * @param interp - interpreter running the command.
+ * @param objv   - command line words.
+ * 
+ * @note all errors are reported by exception.
+ * @note the caller has ensured there are two values.
+ */
+void
+RunVarCommand::create(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+
+    // Tease out the name of the variable.
+
+    std::string name = objv[1];
+    if (objv.size() > 2) {
+        requireExactly(objv, 3);
+        name = std::string(objv[2]);
+    }
+    // If it's already in the set that's an error:
+
+    if (m_names.count(name)) {
+	std::stringstream smsg;
+	smsg << name << " is already a run variable";
+	std::string msg(smsg.str());
+	throw msg;
+    }
+    CTCLVariable var(&interp, name, TCLPLUS::kfFALSE);
+    if(!var.Get()) {
+        var.Set("");                       // Create if it does not exist.
+    }
+    m_names.insert(name);                  // Add it to the set.
+    interp.setResult(name);                // what the heck use that.
+}
+/**
+ * remove 
+ *    Delete a variable for the monitored set.  The variable name must exist in the set.
+ *    This does not change the variable itself.
+ * 
+ * @param interp - interpreter running the command.
+ * @param objv   - command line words.
+ * 
+ * @note all errors are reported by exception.
+ */
+void
+RunVarCommand::remove(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    // Must be three words:
+
+    requireExactly(objv, 3);
+    std::string name = objv[2];
+    auto p = m_names.find(name);
+    if (p == m_names.end()) {
+        std::stringstream msg;
+        msg << "runvar remove - " << name << " is not in the list of monitored variables";
+        std::string smsg(msg.str());
+        throw smsg;
+    }
+    m_names.erase(p);
+}
+/**
+ * list
+ *   Takes an optional pattern (defaults to "*").  Sets the result to the (possibly empty) list of
+ * matching names.alignas
+ * 
+ * @param interp - interpreter running the command.
+ * @param objv   - command line words.
+ * 
+ */
+void
+RunVarCommand::list(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    std::string pattern("*");
+    requireAtMost(objv, 3);
+    if (objv.size() == 3) {
+        pattern = std::string(objv[2]);
+    }
+    CTCLObject result;
+    result.Bind(interp);
+    for (auto name : m_names) {
+        if (Tcl_StringMatch(name.c_str(), pattern.c_str())) {
+            CTCLObject item; 
+            item.Bind(interp);
+            item = name;
+            result += item;
+        }
+    }
+
+    interp.setResult(result);
+}

--- a/extras/fribdaq/src/RunVarCommand.h
+++ b/extras/fribdaq/src/RunVarCommand.h
@@ -1,0 +1,93 @@
+/**
+ * @file RunVarCommand.h
+ * @brief Defines the TCL class that manages ruvars.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_RUNVARCOMMAND_H
+#define MVLC_RUNVARCOMMAND_H
+#include "ReadoutCommand.h"
+#include <TCLTimer.h>        // Eventually we'll have a timer class to make/dump buffers.
+#include <set>
+#include<string>
+
+struct FRIBDAQRunState;
+namespace mesytec {
+    namespace mvlc {
+        class MVLCReadout;
+    }
+}
+/**
+ *  @class RunVarCommand
+ * 
+ *   The purpose of this class is to 
+ *   1. Maintain a set of variables and
+ *   2. Periodically dump those variables to the ringbuffer s CRingTextItems with type MONITORED_VARIABLES
+ * 
+ * @note The following varibles are pre-created:
+ *      -  title  - title of the run.
+ *      -  run    - run number.
+ * 
+ * @note creating a runvar also creates the Tcl variable with an empty string.  Deleting one does not
+ * destroty the variable itself.
+ */
+class RunVarCommand : public ReadoutCommand {
+    // Internal classes
+
+    class Dumper : public CTCLTimer {
+    private:
+        RunVarCommand& m_owner;
+    public:
+        Dumper(RunVarCommand& owner);
+        virtual ~Dumper();
+        virtual void operator()();
+    private:
+        void dumpVars();
+        std::string buildScript(CTCLInterpreter* interp, const char* name, const char* value);
+    };
+    // Class private data.
+private:
+    std::set<std::string> m_names;  // names of variables that are runvars.
+    Dumper                m_dumper; // Periodic dump method.
+
+    // exported canonicals:
+
+public:
+    RunVarCommand(
+        CTCLInterpreter& interp,
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~RunVarCommand();
+
+    // forbidden canonicals:
+
+private:
+    RunVarCommand(const RunVarCommand&);
+    RunVarCommand& operator=(const RunVarCommand&);
+    int operator==(const RunVarCommand&);
+    int operator!=(const RunVarCommand&);
+
+    // Base class overrides:
+public:
+    virtual int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+
+    // Utility methods:
+private:
+    void create(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+    void remove(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+    void list(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+
+};
+
+
+#endif

--- a/extras/fribdaq/src/StateUtils.cc
+++ b/extras/fribdaq/src/StateUtils.cc
@@ -1,0 +1,84 @@
+/**
+ * @file StateUtils.cc
+ * @brief Implement functions that are useful for all state change commands.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ */
+
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include "parser_callbacks.h"
+
+
+ /** 
+  * canBegin
+ * We can begine a run if the following conditions obtain:
+ * - The state in FRIBDAQRunState is Halted 
+ * - the Readout is finished - that is the workers have all
+ * rundown.
+ *   @param rdo - the readout object.
+ *   @param ExtraRunState - the run state struct.
+ *   @return bool - true if the run can be begun.
+ */
+bool 
+canBegin(mesytec::mvlc::MVLCReadout& rdo, FRIBDAQRunState& ExtraRunState) {
+    return (
+        ExtraRunState.s_runState == Halted &&
+        rdo.finished()
+    ); 
+}
+
+/**
+ * canEnd
+ *   We can end a run if the following conditions hold
+ *    - We are paused and the readout is finished.
+ *    - We are Active.
+ * @param ExtraRunState -The extra state for the run:
+ * @return bool - true if it's legal to end the run.
+ */
+bool
+canEnd(FRIBDAQRunState& ExtraRunState) {
+    return (
+        (ExtraRunState.s_runState == Active) ||
+        (ExtraRunState.s_runState == Paused)
+    );
+}
+
+/**
+ * canPause
+ *     Determine if it is legal to pause the run.
+ * The run must be active for this to be legal:
+ * @param ExtraRunState - state of the run.
+ * @return bool - true if the run can be paused.
+ */
+
+bool
+canPause(FRIBDAQRunState& ExtraRunState) {
+    return ExtraRunState.s_runState == Active;
+}
+
+
+
+/**
+ * canResume
+ *    Determine if resuming a run is legal.
+ * This is the case if we are Paused and finished.
+ * 
+ * @param ExtraRunState - the run state struct.
+ * @return bool -True if legal.
+ */
+
+ bool
+ canResume(FRIBDAQRunState& ExtraRunState) {
+     return 
+         (ExtraRunState.s_runState == Paused);
+     
+ }

--- a/extras/fribdaq/src/StateUtils.h
+++ b/extras/fribdaq/src/StateUtils.h
@@ -1,0 +1,40 @@
+/**
+ * @file StateUtils.h
+ * @brief Define functions that are useful for all state change commands.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ */
+
+ #ifndef MVLC_STATEUTILS_H
+ #define MVLC_STATEUTILS_H
+
+// Forward defs.
+struct FRIBRunState;
+namespace mesytec {
+    namespace mvlc {
+        class  MVLCReadout;        
+    }
+}
+
+extern bool 
+canBegin(mesytec::mvlc::MVLCReadout& rdo, FRIBDAQRunState& ExtraRunState);
+
+extern bool
+canEnd(FRIBDAQRunState& ExtraRunState);
+
+extern bool 
+canPause(FRIBDAQRunState& ExtraRunState);
+
+extern bool
+canResume(FRIBDAQRunState& ExtraRunState);
+
+ #endif

--- a/extras/fribdaq/src/StatisticsCommand.cc
+++ b/extras/fribdaq/src/StatisticsCommand.cc
@@ -1,0 +1,113 @@
+/**
+ * @file StatisticsCommand.cc
+ * @brief Implements the Tcl command that returns run statistics.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "StatisticsCommand.h"
+#include "parser_callbacks.h"
+#include <TCLInterpreter.h>
+#include <TCLObject.h>
+
+
+/**
+ *  @constructor
+ *     @param interp - interpreter to register the commadn on.
+ *     @param pState - the run state struct.
+ *     @param pReadout - The readouit object.
+ */
+StatisticsCommand::StatisticsCommand(
+CTCLInterpreter& interp, 
+FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+) : 
+    ReadoutCommand(interp, "statistics", pState, pReadout) {}
+
+    /** 
+ * destructor
+ */
+StatisticsCommand::~StatisticsCommand() {}
+
+
+/**
+ * operator() 
+ *    Implements the command:
+ * ```
+ *   Ensure there are no command parameters.
+ *   Marshall the cumulative counters.
+ *   Marshall the run counters.
+ *   Set the result as [list cumulative run]
+ * 
+ * ```
+ *    @param interp - interpreter running the command.
+ *    @param objv   - The command words.
+ *    @return int   - TCL_OK on success, or TCL_ERROR if not.
+ * 
+ * The only failure possible is  the user handing us some parameters.
+ * 
+ */
+int
+StatisticsCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    if (objv.size() > 1) {
+        interp.setResult("statistics - too many command line parameters");
+        return TCL_ERROR;
+    }
+    CTCLObject cumulative;
+    CTCLObject run;
+
+    MarshallStats(
+        interp, cumulative, 
+        m_pRunState->s_cumulative_events, m_pRunState->s_cumulative_events
+    );
+    MarshallStats(
+        interp, run, m_pRunState->s_events, m_pRunState->s_bytes
+    );
+
+    CTCLObject result;
+    result.Bind(interp);
+    result += cumulative;
+    result += run;
+
+    interp.setResult(result);
+    return TCL_OK;
+}
+/////////////////////////////////////////////// private utils. 
+
+/**
+ * MarshallStats
+ *    Collect the statistics for triggers and bytes into a three eleme3nt list of
+ *     triggers, accdepted trigggers and bytes.  Note that for the MVLC< triggers == accepted-triggers.
+ * 
+ * @param interp  - an interpreter that CTCLObjects can be bound into
+ * @param[out] result - the object into which the list is made (not assumed to be bound).
+ * @param triggers - number of triggers.
+ * @param bytes   - number of bytes.
+ */
+void
+StatisticsCommand::MarshallStats(
+    CTCLInterpreter& interp, CTCLObject& result, 
+    unsigned long triggers, unsigned long bytes
+    
+) {
+    result.Bind(interp);
+
+    CTCLObject trigs;
+    trigs.Bind(interp);
+    trigs = (double)(triggers);
+    result += trigs;
+    result += trigs;
+    
+    CTCLObject b;
+    b.Bind(interp);
+    b = (double)(bytes);
+    result += b;
+}

--- a/extras/fribdaq/src/StatisticsCommand.h
+++ b/extras/fribdaq/src/StatisticsCommand.h
@@ -1,0 +1,64 @@
+/**
+ * @file StatisticsCommand.h
+ * @brief Defines the Tcl command that returns run statistics.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef MVLC_STATISTICSCOMMAND_H
+#define MVLC_STATISTICSCOMMAND_H
+
+#include "ReadoutCommand.h"
+
+
+/**
+ *  @class StatisticsCommand
+ * 
+ *  Implements the 'statistics' command.  This command takes no parameters.  It 
+ * returns a two elemnt list.  The elements of the first list are cumulative counters
+ * (over all runs).  The elements of the second list are counters for the current (or last run).
+ * Each sub-list has, in order
+ *   *   Number of triggers
+ *   *   Number of accepted triggers - same as above for mvlc readout.
+ *   *   Number of bytes of event data (this is exclusive of e.g. ring item wrapping and body headers).
+ * 
+ * @note statistics are maintained by the parser_callbacks.cc  file.
+ */
+class StatisticsCommand  : public ReadoutCommand {
+    // Exported canonicals:
+public:
+    StatisticsCommand(
+        CTCLInterpreter& interp, 
+        FRIBDAQRunState* pState, mesytec::mvlc::MVLCReadout* pReadout
+    );
+    virtual ~StatisticsCommand();
+
+    // Forbidden canonicals
+
+private:
+    StatisticsCommand(const StatisticsCommand&);
+    StatisticsCommand& operator=(const StatisticsCommand&);
+    int operator==(const StatisticsCommand&);
+    int operator!=(const StatisticsCommand&);
+
+    // Base class methods overrides and pure virtual implementations.
+public:
+    virtual int operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
+
+private:
+    void MarshallStats(
+        CTCLInterpreter& interp, CTCLObject& result, 
+        unsigned long triggers, unsigned long bytes
+    );
+};
+
+#endif

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include "command_parse.h"
 #include "parser_callbacks.h"
+#include "StateUtils.h"
 #include "username.h"
 #include <CRingBuffer.h>
 #include <Exception.h>
@@ -31,6 +32,22 @@
 
 #include <mesytec-mvlc/mesytec-mvlc.h>
 #include <lyra/lyra.hpp>
+
+/* Issue #5 - better command handling - use Tcl event driven input interpreter */
+#include "BeginCommand.h"
+#include "EndCommand.h"
+#include "PauseCommand.h"
+#include "ResumeCommand.h"
+#include "RunStateCommand.h"
+#include "RunVarCommand.h"
+#include "InitCommand.h"
+#include "StatisticsCommand.h"
+#include <TCLInterpreter.h>
+#include <TCLLiveEventLoop.h>
+#include <TCLVariable.h>
+#include <Exception.h>
+#include <tcl.h>
+
 
 using std::cout;
 using std::cerr;
@@ -51,111 +68,11 @@ static FRIBDAQRunState ExtraRunState;
 
 
 /**
- *  return true if stdin is readable:
- */
-static bool stdinPending() {
-    fd_set empty;
-    fd_set has_stdin;
-    FD_ZERO(&has_stdin);
-    FD_SET(STDIN_FILENO, &has_stdin);
-
-    timeval immediately = {tv_sec: 0, tv_usec: 0};
-
-    int status = select(STDIN_FILENO + 1, &has_stdin, &empty, &empty, &immediately);
-
-    // errors are ok if errno is EINTR
-
-    if (status < 0) {
-        if (errno == EINTR) {
-            // just a signal.
-            return false;
-        } else {
-            // a real error probably my programming error so fatal:
-
-            std::cerr << "Check for stdin readable failed: " << strerror(errno) << std::endl;
-            std::exit(EXIT_FAILURE);
-
-        }
-    } else if (status ==  0) {
-        // no fds:
-        return false;
-    } else {
-        // Don't think I need to check has_stdin but I will anyway:
-
-        return FD_ISSET(STDIN_FILENO, &has_stdin);
-    }
-}
-/**
- * return a line of input from std::cin
+ * This struct is passed to the exti handler.  It needs all that stuff to 
+ * clean up prior to the actual exit.alignas
  * 
- * @return std::string
- * @note this will block until a line is available. so maybe best to check stdinPending 
- *     before calling if that's not desireable.
  */
-std::string
-getStdinLine() {
-    std::string result;
-    std::getline(std::cin, result);
-    return result;
-}
 
-/// functions to check that state transitions are legal:
-
-/** canBegin
- * We can begine a run if the following conditions obtain:
- * - The state in FRIBDAQRunState is Halted 
- * - the Readout is finished - that is the workers have all
- * rundown.
- *    @param rdo - references the readout object.
- *    @return bool - true if the run can be begun.
- */
-static bool 
-canBegin(MVLCReadout& rdo) {
-    return (
-        ExtraRunState.s_runState == Halted &&
-        rdo.finished()
-    ); 
-}
-/**
- * canEnd
- *   We can end a run if the following conditions hold
- *    - We are paused and the readout is finished.
- *    - We are Active.
- * @param rdo - the MVLCREadout object (referenced)
- * @return bool - true if it's legal to end the run.
- */
-static bool
-canEnd(MVLCReadout& rdo) {
-    return (
-        (ExtraRunState.s_runState == Active) ||
-        (ExtraRunState.s_runState == Paused)
-    );
-}
-/**
- * canPause
- *     Determine if it is legal to pause the run.
- * The run must be active for this to be legal:
- * @param rdo - Readout object (unused for this but makes the calls the same).
- * @return bool - true if the run can be paused.
- */
-static bool
-canPause(MVLCReadout& rdo) {
-    return ExtraRunState.s_runState == Active;
-}
-/**
- * canResume
- *    Determine if resuming a run is legal.
- * This is the case if we are Paused and finished.
- * 
- * @param rdo - the readout object.
- * @return bool -True if legal.
- */
-static bool
-canResume(MVLCReadout& rdo) {
-    return 
-        (ExtraRunState.s_runState == Paused);
-    
-}
 /**
  * loadTimestampExtrctor
  *   Loads a shared object that contains a function named 'extract_timestamp' that better be a 
@@ -203,6 +120,7 @@ loadTimestampExtractor(const std::string libName) {
     dlclose(dlhandle);
     return reinterpret_cast<TimestampExtractor>(extractor);
 }
+
 /////////////////////
 StackErrorCounters delta_counters(const StackErrorCounters &prev, const StackErrorCounters &curr)
 {
@@ -265,7 +183,12 @@ struct MiniDaqCountersUpdate
     MiniDaqCountersSnapshot curr;
     std::chrono::milliseconds dt;
 };
+struct ExitInfo {
+    MVLCReadout*  s_readout;
+    MVLC*         s_mvlc;
+    CrateConfig*  s_config;
 
+} exitinfo;
 void dump_counters2(
     std::ostream &out,
     const MiniDaqCountersSnapshot &prev,
@@ -429,7 +352,47 @@ void dump_counters(
         readout_parser::print_counters(cout, parserCounters);
     }
 }
+/**
+ *  exit_cleanup 
+ *     This  code is, presumably, called as Tcl is exiting.  It gives us the chance
+ * to do the post main loop cleanup that had been done after the while main loop in minidaq.
+ * 
+ * @param data - actually a pointer to an ExitInfo
+ */
+void exit_cleanup(ClientData data) {
+    ExitInfo* pInfo = reinterpret_cast<ExitInfo*>(data);
 
+    // some more casts because I'm lazy:
+
+    MVLC& mvlc = *pInfo->s_mvlc;
+    CrateConfig& crateConfig = *pInfo->s_config;
+    MVLCReadout& rdo = *pInfo->s_readout;
+
+    mvlc.disconnect();
+
+
+    auto cmdPipeCounters = mvlc.getCmdPipeCounters();
+
+    spdlog::debug("CmdPipeCounters:\n"
+                  "    reads={}, bytesRead={}, timeouts={}, invalidHeaders={}, wordsSkipped={}\n"
+                  "    errorBuffers={}, superBuffer={}, stackBuffers={}, dsoBuffers={}\n"
+                  "    shortSupers={}, superFormatErrors={}, superRefMismatches={}, stackRefMismatches={}",
+
+                  cmdPipeCounters.reads,
+                  cmdPipeCounters.bytesRead,
+                  cmdPipeCounters.timeouts,
+                  cmdPipeCounters.invalidHeaders,
+                  cmdPipeCounters.wordsSkipped,
+                  cmdPipeCounters.errorBuffers,
+                  cmdPipeCounters.superBuffers,
+                  cmdPipeCounters.stackBuffers,
+                  cmdPipeCounters.dsoBuffers,
+
+                  cmdPipeCounters.shortSuperBuffers,
+                  cmdPipeCounters.superFormatErrors,
+                  cmdPipeCounters.superRefMismatches,
+                  cmdPipeCounters.stackRefMismatches);
+}
 int main(int argc, char *argv[])
 {
     // MVLC connection overrides
@@ -457,6 +420,7 @@ int main(int argc, char *argv[])
     std::string opt_timestampdll;
     std::string opt_ringBufferName = getUsername();
     unsigned opt_sourceid = 0; 
+    std::string opt_initscript;   // Tcl init script.
 
     auto cli
         = lyra::help(opt_showHelp)
@@ -505,6 +469,7 @@ int main(int argc, char *argv[])
         | lyra::opt(opt_ringBufferName, "ring")["--ring"]("ring buffer name")
         | lyra::opt(opt_sourceid, "sourceid")["--sourceid"]("Event builder source id")
         | lyra::opt(opt_timestampdll, "dll")["--timestamp-library"]("Time stamp shared library file")
+        | lyra::opt(opt_initscript, "initscript")["--init-script"]("Tcl initialization script")
         // logging
         | lyra::opt(opt_logDebug)["--debug"]("enable debug logging")
         | lyra::opt(opt_logTrace)["--trace"]("enable trace logging")
@@ -536,6 +501,9 @@ int main(int argc, char *argv[])
             << "'File -> Export VME Config' menu entry in mvme." << endl << endl
             << "Alternatively a CrateConfig object can be generated programmatically and" << endl
             << "written out using the to_yaml() free function."
+            << endl  << "Starting with FRIB/NSCLDAQ-12.2 a tool exists (mvlcgenerate) to translate VMUSB" << endl
+            << "config.tcl files to yaml configuration files.  That's probably the normal way" << endl
+            << "Users of this will get their cofigurations."
             << endl;
         return 0;
     }
@@ -686,172 +654,65 @@ int main(int argc, char *argv[])
         );
 
         MiniDaqCountersUpdate counters;
-        Stopwatch sw;
-        bool running = true;
-        while (running)                  // main loop/
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));   // one second.
-            // If we are active, count a second:
+        
 
-            if (ExtraRunState.s_runState == Active) {
-                ExtraRunState. s_runtime += 1000;                          // one second has passed.
-            }
+        // FIll in the struct the exit handler needs:
 
-            if (stdinPending()) {                    // Process commands.
-                auto line = getStdinLine();
-                if (!isBlank(line)) {
-                    auto parsed = parseCommand(line);
+        exitinfo.s_readout = &rdo;
+        exitinfo.s_mvlc    = &mvlc;
+        exitinfo.s_config  = &crateConfig;
 
-                    // Command specific processing:
+        // FIll in the interface, config and readout parts of the state:
+        // TODO:  exitinfo could now just be the extra run state.
+        ExtraRunState.s_interface = &mvlc;
+        ExtraRunState.s_config    = &crateConfig;
+        ExtraRunState.s_readout   = &rdo;
 
 
-                    switch (parsed.s_command) {
-                        case BEGIN:
-                            // start the run:
-                            if (canBegin(rdo)) {
-                                spdlog::info("Starting readout. Running for {} seconds.", timeToRun.count());
-                                auto ec = rdo.start(timeToRun);
-                                
-                                if (ec) {
-                                    std::cerr << "Failed to stat the run" << ec.message() << std::endl;
-                                } else {
-                                    ExtraRunState.s_runState = Active;  // Transition on success.
-                                }
-                            } else {
-                                std::cerr << "Run state does not allow us to start a run\n";
-                            }
-                            break;
-                        case END:
-                            if (canEnd(rdo)) {
-                                spdlog::info("Ending the run");
-                                auto ec = rdo.stop();
-                                if (ec) {
-                                    std::cerr << "Failed to end the run: " << ec.message() << std::endl;
-                                } else {
-                                    ExtraRunState.s_runState = Halted;
-                                }
-                            } else {
-                                std::cerr << "Run state does not allow us to end the run.\n";
-                            }
-                            break;
-                        case PAUSE:
-                            if (canPause(rdo)) {
-                                spdlog::info("Pausing active run");
-                                auto ec = rdo.pause();
-                                if (ec) {
-                                    std::cerr << "Failed to pause the run: " << ec.message() << std::endl;
-                                } else {
-                                    ExtraRunState.s_runState = Paused;
-                                }
-                            } else {
-                                std::cerr << " Run state does not allow us to pause a run\n";
-                            }
-                            break;
-                        case RESUME:
-                            if (canResume(rdo)) {
-                                spdlog::info("Resuming paused run");
-                                auto ec = rdo.resume();
+        // Let's set up the Tcl interpreter and live event loop.
+        //
+        CTCLInterpreter interp;                       // The interpreter that will run things
+        Tcl_CreateExitHandler(exit_cleanup, &exitinfo);
 
-                                if (ec) {
-                                    std::cerr << "Unable to resume paused run" << ec.message() << std::endl;
-                                } else {
-                                    ExtraRunState.s_runState = Active;
-                                }
-                            } else {
-                                std::cerr << "Run state does not allow us to resume a run\n";
-                            }
-                            break;
-                        case TITLE:
-                            if (ExtraRunState.s_runState != Halted) {
-                                std::cerr << "Run state must be halted to set the title.";
-                            } else {
-                                ExtraRunState.s_runTitle = parsed.s_stringarg;
-                            }
-                            break;
-                        case SETRUN:
-                            if (ExtraRunState.s_runState != Halted) {
-                                std::cerr << "Run state must be halted to set the run number\n";
-                            } else {
-                                ExtraRunState.s_runNumber = parsed.s_intarg;                            }
-                            break;
-                        case EXIT:
-                            if (ExtraRunState.s_runState != Halted) {
-                                // force  the end run if we're not halted
-                                spdlog::info("Forcing end run due to exit");
-                                rdo.stop();
-                                // Wait for it to finish:
+        // Initialize the run and title and state variables:
 
-                                while (!rdo.finished()) {
-                                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                                }
-                            }
-                            running = false;    // Allow the loop to exit.;
-                            break;
-                        case INVALID:
-                            std::cerr << parsed.s_error << std::endl;
-                            break;
-                        default:
-                            std::cerr << "Unsupported command '" << line << "'\n";
-                            break;
-                    }
-                }
-                
+        CTCLVariable title("title", TCLPLUS::kfFALSE); title.Bind(interp);
+        title.Set(ExtraRunState.s_runTitle.c_str());
 
-            }
+        CTCLVariable run("run", TCLPLUS::kfFALSE); run.Bind(interp);
+        run.Set("0");                // yes there's an assumption there.
 
-            // If the run is active, dump the counters.
+        CTCLVariable state("state", TCLPLUS::kfFALSE); state.Bind(interp);
+        state.Set("idle");
 
-            if (!opt_noPeriodicCounterDumps && (ExtraRunState.s_runState == Active)) 
-            {
-                dump_counters(
-                    cout,
-                    crateConfig.connectionType,
-                    mvlc.getStackErrorCounters(),
-                    rdo.workerCounters(),
-                    rdo.parserCounters());
+        // Add the commands:
 
-                update_counters(counters, rdo, std::chrono::duration_cast<std::chrono::milliseconds>(sw.interval()));
-                dump_counters2(cout, counters.prev, counters.curr, counters.dt);
+        BeginCommand begin(interp, &ExtraRunState, &rdo, opt_crateConfig);     // Register the begin command.
+        EndCommand end(interp, &ExtraRunState, &rdo);
+        PauseCommand pause(interp, &ExtraRunState, &rdo);
+        ResumeCommand resume(interp, &ExtraRunState, &rdo);
+        RunStateCommand runstate(interp);
+	InitCommand init(interp, &ExtraRunState, &rdo);
+	RunVarCommand runvar(interp, &ExtraRunState, &rdo);
+        StatisticsCommand stats(interp, &ExtraRunState, &rdo);
 
+        // Before starting the event loop, run any initialization script.
+
+        if (opt_initscript != "") {
+            try {
+                interp.EvalFile(opt_initscript);
+            } catch (CException & e) {
+                std::stringstream smsg;
+                smsg << "Failed to run initialization script: " << opt_initscript << " : "
+                    << e.ReasonText();
+                return 0;
             }
         }
 
-        mvlc.disconnect();
+        // Start the Tcl event loop.
 
-        cout << endl << "Final stats dump:" << endl;
-
-        dump_counters(
-            cout,
-            crateConfig.connectionType,
-            mvlc.getStackErrorCounters(),
-            rdo.workerCounters(),
-            rdo.parserCounters());
-
-        update_counters(counters, rdo, std::chrono::duration_cast<std::chrono::milliseconds>(sw.interval()));
-        dump_counters2(cout, counters.prev, counters.curr, counters.dt);
-
-
-        auto cmdPipeCounters = mvlc.getCmdPipeCounters();
-
-        spdlog::debug("CmdPipeCounters:\n"
-                      "    reads={}, bytesRead={}, timeouts={}, invalidHeaders={}, wordsSkipped={}\n"
-                      "    errorBuffers={}, superBuffer={}, stackBuffers={}, dsoBuffers={}\n"
-                      "    shortSupers={}, superFormatErrors={}, superRefMismatches={}, stackRefMismatches={}",
-
-                      cmdPipeCounters.reads,
-                      cmdPipeCounters.bytesRead,
-                      cmdPipeCounters.timeouts,
-                      cmdPipeCounters.invalidHeaders,
-                      cmdPipeCounters.wordsSkipped,
-                      cmdPipeCounters.errorBuffers,
-                      cmdPipeCounters.superBuffers,
-                      cmdPipeCounters.stackBuffers,
-                      cmdPipeCounters.dsoBuffers,
-
-                      cmdPipeCounters.shortSuperBuffers,
-                      cmdPipeCounters.superFormatErrors,
-                      cmdPipeCounters.superRefMismatches,
-                      cmdPipeCounters.stackRefMismatches);
+        CTCLLiveEventLoop* pEventLoop = CTCLLiveEventLoop::getInstance();
+        pEventLoop->start(&interp);             // TODO: Catch the exit and do the cleanup.       
 
         return 0;
     }

--- a/extras/fribdaq/src/parser_callbacks.cc
+++ b/extras/fribdaq/src/parser_callbacks.cc
@@ -19,7 +19,7 @@
 
 // A note:  We could use the unified format library but then we'd need to 
 // generate a ring item factory for a _specific_ FRIB/NSCLDAQ version but
-// we know that what we want to make are ring items for the version of
+// we know that what we want to make are ring items ::for the version of
 // the software we were built against; so using that set is the best - I think.
 // Note that CDataFormatItems only came into being in NSCLDAQ-11.0.
 
@@ -27,11 +27,13 @@
 #include <CRingScalerItem.h>
 #include <CPhysicsEventItem.h>
 #include <CRingPhysicsEventCountItem.h>
+#include <CRingTextItem.h>
 #include <CDataFormatItem.h>       // Requires NSCLDAQ-11.0 and higher.
 #include <stdint.h>
 #include <iostream>
 #include <vector>
 #include <time.h>
+#include <chrono>
 
 
 
@@ -39,7 +41,46 @@ static const int STACK_EVENT(0);
 static const int STACK_SCALER(1);
 static bool bad_stack_warning_given(false);
 
+
 ////////////////////////////// private utilities ////////////////////////////////////////
+
+/** get_milliseconds
+ * 
+ * @return unsigned int - the number of milliseconds into the run we are.
+ */
+static unsigned int get_milliseconds(FRIBDAQRunState* state) {
+    auto now = state->s_timing.get_interval();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now);
+    return ms.count();
+}
+
+/**
+ * emit_statistics
+ *    Emit a CPhysicsEventCountItem for the current statistics.
+ * Note that if there's a timstamp extractor we use a timetamps of 0xffffffffffffffff
+ * which asks the event builder to supply a timestamp.
+ * 
+ * @param context - pointer to the run context.  This supplies the ring buffer, the
+ *      statistics, offset and all of the stuff we need.
+ */
+static void
+emit_statistics(FRIBDAQRunState* context) {
+    std::unique_ptr<CRingPhysicsEventCountItem> item;  // Ensure deletion.
+    if (context->s_tsExtractor) {
+        item.reset(new CRingPhysicsEventCountItem(
+            0xffffffffffffffff, context->s_sourceid, 0,
+            context->s_events, get_milliseconds(context), time(nullptr), context->s_divisor
+        ));
+    } else {
+        item.reset(new CRingPhysicsEventCountItem(
+            context->s_events, get_milliseconds(context), time(nullptr)
+        ));
+        item->setTimeDivisor(context->s_divisor);
+    }
+    std::lock_guard(context->s_serializer);
+    item->commitToRing(*context->s_pRing);
+
+}
 /**
  *  submit_scaler
  * 
@@ -76,17 +117,18 @@ submit_scaler(
     }
     // For now use a source-id of zero.  We'll need to add that to the context and set it up from parameters:
 
+    auto stop_time = get_milliseconds(context);
     CRingScalerItem item (
         0xffffffffffffffff, context->s_sourceid, 0,
-        context->s_lastScalerStopTime, context->s_runtime, time(nullptr), 
+        context->s_lastScalerStopTime, stop_time, time(nullptr), 
         scalers, context->s_divisor
     );
-    
+    std::lock_guard(context->s_serializer);
     item.commitToRing(*(context->s_pRing));
 
     // Start/stop book keeping>
 
-    context->s_lastScalerStopTime = context->s_runtime;    // Start of next interval
+    context->s_lastScalerStopTime = stop_time;    // Start of next interval
 
 
 }
@@ -131,15 +173,23 @@ submit_event(
 
     for ( int i  = 0; i < moduleCount; i++) {
         uint32_t* pCursor = reinterpret_cast<uint32_t*>(event.getBodyCursor());
-        auto size = pModuleDataList->data.size;
-        memcpy(pCursor, pModuleDataList->data.data, size * sizeof(uint32_t));
-        pCursor += size;
-        event.setBodyCursor(pCursor);
+        auto size = pModuleDataList[i].data.size;
+	if (size > 0) {		// In case memcpy is ill behaved for size==0.
+	    memcpy(pCursor, pModuleDataList[i].data.data, size * sizeof(uint32_t));
+	    pCursor += size;
+	    event.setBodyCursor(pCursor);
+	}
     }
     event.updateSize();
-
+    std::lock_guard(context->s_serializer);
     event.commitToRing(*(context->s_pRing));
+
+    // Update the statistics counters
+
     context->s_events++;                            // Update statistics.
+    context->s_bytes += eventSize;
+    context->s_cumulative_events++;
+    context->s_cumulative_bytes += eventSize;
 
 }
 
@@ -152,7 +202,9 @@ submit_event(
 static void
 reset_statistics(  FRIBDAQRunState* context )  {
     context->s_events = 0;
+    context->s_bytes = 0;
     context->s_lastScalerStopTime = 0;
+    context->s_timing.start();
 }
 ////////////////////////////// Public entries ///////////////////////////////////
 /**
@@ -179,6 +231,7 @@ stack_callback(
             submit_event(context, pModuleDataList, moduleCount);
             break;
         case STACK_SCALER:
+            emit_statistics(context);
             submit_scaler(context, pModuleDataList, moduleCount);
             break;
         default:
@@ -222,9 +275,11 @@ void system_event_callback(
         case mesytec::mvlc::system_event::subtype::EndRun:
             itemType= END_RUN;
             barriertype = 1;
+            emit_statistics(context);
             break;
         case mesytec::mvlc::system_event::subtype::Pause:
             itemType = PAUSE_RUN;
+            emit_statistics(context);
             break;
         case mesytec::mvlc::system_event::subtype::Resume:
             itemType = RESUME_RUN;  
@@ -235,6 +290,7 @@ void system_event_callback(
     // Let's emit a format item prior to all of these...
 
     CDataFormatItem fmtItem;
+    std::lock_guard(context->s_serializer);
     fmtItem.commitToRing(*context->s_pRing);
 
     // Note that the constructor for the state change item
@@ -243,8 +299,34 @@ void system_event_callback(
     
     CRingStateChangeItem item( 
         0xffffffffffffffff, context->s_sourceid, barriertype, 
-        itemType, context->s_runNumber, context->s_runtime, 
+        itemType, context->s_runNumber, get_milliseconds(context), 
         time(nullptr), context->s_runTitle, context->s_divisor);
     
     item.commitToRing(*context->s_pRing);
+}
+
+/**
+ * dumpVariables
+ * 
+ *    Create and commit a MONITORED_VARIABLES CRingTextItem.
+ *    a lock guard is used because this is likely called from the main thread
+ * not the thread the normal parser callbacks runin.alignas
+ * 
+ * @param pState - context (has the ringbuffer and mutex)
+ * @param strings - Strings to put in the ring item.
+ *     
+ */
+void
+dumpVariables(FRIBDAQRunState& state, const std::vector<std::string>& strings) {
+    // Always put in a sid and dummy timestamp:
+
+    CRingTextItem item(
+        MONITORED_VARIABLES, 0xffffffffffffffff, state.s_sourceid, 0,
+        strings, get_milliseconds(&state), time(nullptr), state.s_divisor
+    );
+    std::lock_guard(state.s_serializer);
+    item.commitToRing(*state.s_pRing);
+
+
+
 }

--- a/extras/fribdaq/src/parser_callbacks.h
+++ b/extras/fribdaq/src/parser_callbacks.h
@@ -19,12 +19,24 @@
  #define PARSER_CALLBACKS_H
 
  #include <mesytec-mvlc/mvlc_readout_parser.h>
+ #include <mesytec-mvlc/util/stopwatch.h>
  #include <stdint.h>
+ #include <mutex>
+ #include <string>
+ #include <vector>
 
 
  // Forward type definitions:
 
  class CRingBuffer;
+
+ namespace mesytec {
+    namespace mvlc {
+        class MVLC;
+        class MVLCReadout;
+        struct CrateConfig;
+    }
+ }
 
  /**
  *  This block of stuff is passed around to the parsers to provide
@@ -43,24 +55,38 @@ typedef uint64_t (*TimestampExtractor)(unsigned, const mesytec::mvlc::readout_pa
 
 
 struct FRIBDAQRunState {
+    std::mutex s_serializer;
     unsigned s_runNumber;
     std::string s_runTitle;
     FRIBState s_runState;
     CRingBuffer* s_pRing;
     // THe statistics get initialized by begin run state changes.
-    unsigned     s_events;     // Number of accepted events.
-    unsigned     s_runtime;    // Run offset.
-    unsigned     s_lastScalerStopTime;
+    unsigned     s_events;     // Number of accepted events this run.
+    unsigned long    s_bytes;      // Event data bytes this run. COuld be TB.
+    unsigned     s_cumulative_events; // total events over all time.  
+    unsigned long    s_cumulative_bytes;  // total event bytes over all time. Couldb e TB
+    mesytec::mvlc::util::Stopwatch     s_timing;    // Run offset.
+    unsigned     s_lastScalerStopTime;              // ms.
     unsigned     s_divisor;    // Offset divisor. 
     int          s_sourceid;   // Source id for event built case. -1 if not.
     TimestampExtractor s_tsExtractor;
+    mesytec::mvlc::MVLC*        s_interface;  // Pointer to the MVLC interface object.
+    mesytec::mvlc::CrateConfig* s_config;     // Current configuration pointer.
+    mesytec::mvlc::MVLCReadout* s_readout;    // The reaodut object.
+
     
 FRIBDAQRunState() : 
     s_runNumber(0),            // If never set.
-    s_runState(Halted), s_pRing(nullptr),
+    s_runTitle("Change the title please"),
+    s_runState(Halted), 
+    s_pRing(nullptr),
+    s_events(0), s_bytes(0), 
+    s_cumulative_events(0), s_cumulative_bytes(0),
     s_divisor(1000),          // Timing in seconds.
     s_sourceid(0),
-    s_tsExtractor(nullptr)
+    s_tsExtractor(nullptr),
+    s_interface(nullptr),
+    s_config(nullptr)
     {}
     
 };
@@ -98,4 +124,12 @@ void system_event_callback(
     void* cd,
     int crateIndex, const mesytec::mvlc::u32* header, mesytec::mvlc::u32 size
 );
- #endif
+/**
+ * Create and submit a monitoredVariables item:
+ * 
+ * @param context - context pointer.
+ * @param strings - Vector of strings to put in that item.
+ */
+void
+dumpVariables(FRIBDAQRunState& state, const std::vector<std::string>& strings);
+#endif

--- a/src/mesytec-mvlc/mvlc_readout.cc
+++ b/src/mesytec-mvlc/mvlc_readout.cc
@@ -164,7 +164,17 @@ const CrateConfig &MVLCReadout::crateConfig() const
 {
     return d->crateConfig;
 }
-
+/**
+ * setCrateConfiguration
+ *     Provide a new crate configuration  for the readout.
+ * This will be used on the next run to initialize and
+ * to define the readout.alignas
+ * 
+ * @param[in] config - The new crate configuration.
+ */
+void MVLCReadout::setCrateConfig(CrateConfig config) {
+    d->crateConfig = config;
+}
 ReadoutWorker &MVLCReadout::readoutWorker()
 {
     return *d->readoutWorker;
@@ -179,6 +189,8 @@ std::atomic<bool> &MVLCReadout::parserQuit()
 {
     return d->parserQuit;
 }
+
+
 
 namespace
 {

--- a/src/mesytec-mvlc/mvlc_readout.h
+++ b/src/mesytec-mvlc/mvlc_readout.h
@@ -71,6 +71,9 @@ class MESYTEC_MVLC_EXPORT MVLCReadout
         std::thread &parserThread();
         std::atomic<bool> &parserQuit();
 
+        // Mutators:
+
+        void setCrateConfig(CrateConfig config);
     private:
         MVLCReadout();
 


### PR DESCRIPTION
Functional additions:
FRIBDAQ readout:
*  Built out the full set of commands a FRIBDAQ/Readout is expected to have;
in a Tcl-interpreter running in an eventloop.
* Output run statistics data ring items along with scaler data.
* Add the ability to run an --init-script which will should support ReST command server for FRIB/NSCLDAQ's managed experiment environment.
* Reread the configuration file on run start.   See below

Base software:
*  Added setCrateConfig method to MVLCReadout so the crate config can be changed between runs.


Bugfix:
   Error in processing event stack data that led to duplicated data.