### PR TITLE
In fribdaq-readout support direct use of .tcl configuration files.

### DIFF
--- a/extras/fribdaq/Readme.md
+++ b/extras/fribdaq/Readme.md
@@ -27,6 +27,11 @@ sense in the context of the FRIB/NSCLDAQ environment have been removed.
 * ```--ring ringname```  selects the name of the ring buffer to which the data should be written.  This is a ring name not a URI, as only local ringbuffers can be written to.  If the option is not provided, this defaults to the name of the logged in user.
 * ```--sourceid id``` When used in a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies the unique integer source id  that will be used to identify fragments from this data source.   If not provided, this defaults to 0.
 * ```--timestamp-library``` When used with a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies a shared library file which includes code to extract timestamps from the raw event data.   If not provided, the body headers required to build events will not be included in the ```PHYSCIS_EVENT``` items.
+* ```--convert-tcl``` Requires a setup version of NSCLDAQ (```DAQBIN``` environment variable defined) with ```mvlcgenerate``` in ```DAQBIN```.  If used, the configuration file is treate as a Tcl script describing the experimewnt suitable as input for ```mvlcgenerate```.   At startup, and the prior to the beginning of each run, ```mvlcgenerate``` is run to convert that file to a yaml crate configitation file.  The converted file is then
+used as the configuration file.  The converted filename is generated from the configuration file name prepending it with a ```.``` to make it a hidden file and appending ```.yaml```.  E.g the configuration file 
+```daqconfig.tcl``` will be converted to ```.daqconfig.tcl.yaml```.
+* ```--template``` this option only makes sense when ```--convert-tcl``` is used. The parameter to this option will be used by ```mvlcgenerate``` as the template yaml file into which the configuration is converted.  This
+supports the use of non-default trigger conditions.  See the ```--template``` option on the FRIB/NSCLDAQ documentation for ```mvlcgenerate```.
 
 Following all options on the command line, a single positional parameter provides the name of a .yaml configuration file that was either exported from ```mdaq``` or produced using the FRIBDA/NSCLDAQ configuration tools mvlcgenerate in FRIB/NSCLDAQ version 12.2 and later.
 

--- a/extras/fribdaq/src/BeginCommand.cc
+++ b/extras/fribdaq/src/BeginCommand.cc
@@ -27,6 +27,11 @@
 
 using mesytec::mvlc::MVLCReadout;
 
+// for translating tcl -> yaml
+
+
+extern void regenerateCrateFileIfNeeded(const std::string& crateFile);
+
 /**
  * constructor
  *    @param interp - encapsulated Tcl interpreter on which the command is registered.
@@ -79,6 +84,7 @@ BeginCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv)
 
     if (canBegin(*m_pReadout, *m_pRunState)) {
         try {
+            regenerateCrateFileIfNeeded(m_configFileName);
             setConfiguration();                // Update the configuration.
             // Set title and runn um if can:
 


### PR DESCRIPTION
Adds:
*  add --convert-tcl option which treats the configuration file as input to $DAQBIN/mvlcgenerate which will then generate the yaml file prior to starting each run (input files like /some/path/yadayada.tcl get converted to /some/path/yadayada.tcl.yaml).
* Add --template _file-path_ which allows the user to pass a custom yaml template file on to mvlcconvert if --convert-tcl is specified.  This supports user created triggers for the event/scaler stacks.